### PR TITLE
Add a userscript name formatter arg to build()

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ The default build function provides all these features, but you can also write y
 	import { build } from '@kellnerd/userscript-bundler';
 
 	build({
-		userscriptBasePath: 'src/userscripts',
-		bookmarkletBasePath: 'src/bookmarklets', // bookmarklets are optional
-		docBasePath: 'doc',
+		userscriptSourcePath: 'src/userscripts',
+		bookmarkletSourcePath: 'src/bookmarklets', // bookmarklets are optional
+		docSourcePath: 'doc',
 	});
 	```
 

--- a/src/build.js
+++ b/src/build.js
@@ -9,9 +9,18 @@ import { getMarkdownFiles } from './getFiles.js'
 import { sourceAndInstallButton } from './github.js';
 import { loadMetadata } from './userscriptMetadata.js';
 
+/**
+ * Returns the formatted name of the userscript for use in documentation.
+ * @type {import('./types/BuildOptions.js').UserscriptNameFormatter}
+ */
+function defaultNameFormatter({ metadata }) {
+	return metadata.name;
+}
+
 export async function build({
 	bookmarkletBasePath = false,
 	userscriptBasePath = 'src/userscripts',
+	userscriptNameFormatter = defaultNameFormatter,
 	readmePath = 'README.md',
 	docBasePath = 'doc',
 	debug = false,
@@ -34,7 +43,7 @@ export async function build({
 		const filePath = path.join(userscriptBasePath, baseName + '.user.js');
 		const metadata = await loadMetadata(filePath);
 
-		readme.write(`\n### ${camelToTitleCase(baseName)}\n`);
+		readme.write(`\n### ${userscriptNameFormatter({ baseName, metadata })}\n`);
 		readme.write('\n' + metadata.description + '\n');
 		metadata.features?.forEach((item) => readme.write(`- ${item}\n`));
 		readme.write(sourceAndInstallButton(baseName));

--- a/src/build.js
+++ b/src/build.js
@@ -17,8 +17,18 @@ function defaultNameFormatter({ metadata }) {
 	return metadata.name;
 }
 
+/**
+ * Builds userscripts, prepares bookmarklets and generates a nicely formatted documentation page.
+ * @param {Object} args
+ * @param {string?} args.bookmarkletSourcePath Directory containing bookmarklet source files.
+ * @param {string} args.userscriptSourcePath Directory containing userscript source files.
+ * @param {import('./types/BuildOptions.js').UserscriptNameFormatter} args.userscriptNameFormatter Function used to format userscript names in documentation.
+ * @param {string} args.docSourcePath Directory containing markdown documentation files.
+ * @param {string} args.readmePath Path to write generated README file in markdown format.
+ * @param {boolean} args.debug Flag to enable debug output.
+ */
 export async function build({
-	bookmarkletSourcePath = false,
+	bookmarkletSourcePath = null,
 	userscriptSourcePath = 'src/userscripts',
 	userscriptNameFormatter = defaultNameFormatter,
 	docSourcePath = 'doc',

--- a/src/build.js
+++ b/src/build.js
@@ -19,13 +19,14 @@ function defaultNameFormatter({ metadata }) {
 
 /**
  * Builds userscripts, prepares bookmarklets and generates a nicely formatted documentation page.
- * @param {Object} args
- * @param {string?} args.bookmarkletSourcePath Directory containing bookmarklet source files.
- * @param {string} args.userscriptSourcePath Directory containing userscript source files.
- * @param {import('./types/BuildOptions.js').UserscriptNameFormatter} args.userscriptNameFormatter Function used to format userscript names in documentation.
- * @param {string} args.docSourcePath Directory containing markdown documentation files.
- * @param {string} args.readmePath Path to write generated README file in markdown format.
- * @param {boolean} args.debug Flag to enable debug output.
+ * @param {Object} options
+ * @param {string?} options.bookmarkletSourcePath Directory containing bookmarklet source files.
+ * @param {string} options.userscriptSourcePath Directory containing userscript source files.
+ * @param {import('./types/BuildOptions.js').UserscriptNameFormatter} options.userscriptNameFormatter
+ * Function used to format userscript names in documentation.
+ * @param {string} options.docSourcePath Directory containing markdown documentation files.
+ * @param {string} options.readmePath Path to write generated README file in markdown format.
+ * @param {boolean} options.debug Flag to enable debug output.
  */
 export async function build({
 	bookmarkletSourcePath = null,
@@ -38,10 +39,10 @@ export async function build({
 	const gitRepo = GitRepo.fromPackageMetadata({ userscriptNameFormatter });
 
 	// build userscripts
-	const userscriptNames = await buildUserscripts({ sourcePath: userscriptSourcePath, gitRepo, debug });
+	const userscriptNames = await buildUserscripts(userscriptSourcePath, { gitRepo, debug });
 
 	// prepare bookmarklets (optional)
-	const bookmarklets = bookmarkletSourcePath ? await buildBookmarklets(bookmarkletSourcePath, debug) : {};
+	const bookmarklets = bookmarkletSourcePath ? await buildBookmarklets(bookmarkletSourcePath, { debug }) : {};
 
 	// prepare README file and write header
 	const readme = fs.createWriteStream(readmePath);

--- a/src/build.js
+++ b/src/build.js
@@ -6,7 +6,7 @@ import { buildBookmarklets } from './buildBookmarklets.js';
 import { buildUserscripts } from './buildUserscripts.js';
 import { extractDocumentation } from './extractDocumentation.js';
 import { getMarkdownFiles } from './getFiles.js'
-import { sourceAndInstallButton } from './github.js';
+import { GitRepo } from './github.js';
 import { loadMetadata } from './userscriptMetadata.js';
 
 /**
@@ -35,8 +35,10 @@ export async function build({
 	readmePath = 'README.md',
 	debug = false,
 } = {}) {
+	const gitRepo = GitRepo.fromPackageMetadata({ userscriptNameFormatter });
+
 	// build userscripts
-	const userscriptNames = await buildUserscripts(userscriptSourcePath, debug);
+	const userscriptNames = await buildUserscripts({ sourcePath: userscriptSourcePath, gitRepo, debug });
 
 	// prepare bookmarklets (optional)
 	const bookmarklets = bookmarkletSourcePath ? await buildBookmarklets(bookmarkletSourcePath, debug) : {};
@@ -56,7 +58,7 @@ export async function build({
 		readme.write(`\n### ${userscriptNameFormatter({ baseName, metadata })}\n`);
 		readme.write('\n' + metadata.description + '\n');
 		metadata.features?.forEach((item) => readme.write(`- ${item}\n`));
-		readme.write(sourceAndInstallButton(baseName));
+		readme.write(gitRepo.sourceAndInstallButton(baseName));
 
 		// also insert the code snippet if there is a bookmarklet of the same name
 		const bookmarkletFileName = baseName + '.js';

--- a/src/buildBookmarklets.js
+++ b/src/buildBookmarklets.js
@@ -9,14 +9,15 @@ import { getScriptFiles } from './getFiles.js';
 
 /**
  * Builds a bookmarklet for each JavaScript module inside the given source directory.
- * @param {string} srcPath Source directory containing the modules.
+ * @param {string} sourcePath Source directory containing the executable modules.
+ * @param {import('./types/BuildOptions.js').BookmarkletBuildOptions} options
  * @returns {Promise<{[name: string]: string}>} Object which maps script names to bookmarklets.
  */
-export async function buildBookmarklets(srcPath, debug = false) {
-	const scriptFiles = await getScriptFiles(srcPath);
+export async function buildBookmarklets(sourcePath, options) {
+	const scriptFiles = await getScriptFiles(sourcePath);
 	const bookmarklets = await Promise.all(scriptFiles
-		.map((file) => path.join(srcPath, file))
-		.map((modulePath) => buildBookmarklet(modulePath, debug))
+		.map((file) => path.join(sourcePath, file))
+		.map((modulePath) => buildBookmarklet(modulePath, options))
 	);
 
 	return zipObject(scriptFiles, bookmarklets);
@@ -26,9 +27,10 @@ export async function buildBookmarklets(srcPath, debug = false) {
 /**
  * Bundles and minifies the given module into a bookmarklet.
  * @param {string} modulePath Path to the executable module of the bookmarklet.
+ * @param {import('./types/BuildOptions.js').BookmarkletBuildOptions} options
  * @returns {Promise<string>} Bookmarklet code as a `javascript:` URI.
  */
-export async function buildBookmarklet(modulePath, debug = false) {
+export async function buildBookmarklet(modulePath, { debug = false }) {
 	/**
 	 * Bundle all used modules into an IIFE with rollup.
 	 * @type {import('rollup').RollupOptions}

--- a/src/buildUserscripts.js
+++ b/src/buildUserscripts.js
@@ -6,18 +6,21 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import rollupStrip from '@rollup/plugin-strip';
 
 import { getScriptFiles } from './getFiles.js';
+import { GitRepo } from './github.js';
 import { generateMetadataBlock } from './userscriptMetadata.js';
 
 /**
  * Build a userscript for each JavaScript module inside the given source directory.
- * @param {string} srcPath Source directory containing the modules.
+ * @param {Object} args
+ * @param {string} args.sourcePath Source directory containing the modules.
+ * @param {GitRepo} args.gitRepo
  * @returns {Promise<string[]>} Array of userscript file names (without extension).
  */
-export async function buildUserscripts(srcPath, debug = false) {
-	const scriptFiles = await getScriptFiles(srcPath, '.user.js');
+export async function buildUserscripts({ sourcePath, gitRepo, debug = false }) {
+	const scriptFiles = await getScriptFiles(sourcePath, '.user.js');
 	scriptFiles
-		.map((file) => path.join(srcPath, file))
-		.forEach((modulePath) => buildUserscript(modulePath, debug));
+		.map((file) => path.join(sourcePath, file))
+		.forEach((modulePath) => buildUserscript({ sourcePath: modulePath, gitRepo, debug }));
 
 	return scriptFiles.map((file) => path.basename(file, '.user.js'));
 }
@@ -25,22 +28,24 @@ export async function buildUserscripts(srcPath, debug = false) {
 
 /**
  * Bundles the given module into a userscript.
- * @param {string} modulePath Path to the executable module of the userscript.
+ * @param {Object} args
+ * @param {string} args.sourcePath Path containing the executable module of the userscript.
+ * @param {GitRepo} args.gitRepo
  */
-export async function buildUserscript(modulePath, debug = false) {
+export async function buildUserscript({ sourcePath, gitRepo, debug = false }) {
 	/**
 	 * Bundle all used modules with rollup and prepend the generated metadata block.
 	 * @type {import('rollup').RollupOptions}
 	 */
 	const rollupOptions = {
-		input: modulePath,
+		input: sourcePath,
 		treeshake: {
 			moduleSideEffects: false,
 		},
 		output: {
 			dir: 'dist',
 			format: 'iife',
-			banner: generateMetadataBlock(modulePath),
+			banner: generateMetadataBlock(sourcePath, gitRepo),
 		},
 		plugins: [
 			nodeResolve(),
@@ -55,7 +60,7 @@ export async function buildUserscript(modulePath, debug = false) {
 	const bundle = await rollup(rollupOptions);
 
 	if (debug) {
-		console.debug(`${modulePath} depends on:`, bundle.watchFiles);
+		console.debug(`${sourcePath} depends on:`, bundle.watchFiles);
 	}
 
 	await bundle.write(rollupOptions.output);

--- a/src/github.js
+++ b/src/github.js
@@ -8,8 +8,13 @@ export class GitRepo {
 	defaultBranch = 'main';
 	distributionPath = 'dist';
 
-	/** @param {URL} repoUrl */
-	constructor(repoUrl, userscriptNameFormatter) {
+	/**
+	 * @param {URL} repoUrl URL of the git repository which provides the userscripts.
+	 * @param {import('./types/BuildOptions').GitRepoOptions} options
+	 */
+	constructor(repoUrl, {
+		userscriptNameFormatter,
+	}) {
 		const [owner, repoName] = repoUrl.pathname.match(/^\/([^/]+)\/([^/]+?)(?:\.git|$)/)?.slice(1) ?? [];
 		if (!owner || !repoName) throw new Error(`Malformed git repo URL ${repoUrl}`);
 
@@ -29,22 +34,21 @@ export class GitRepo {
 
 	/**
 	 * Instantiates a `GitRepo` object using data parsed from the provided `package.json` file.
-	 * @param {Object} args
-	 * @param {string} args.packageJsonPath
-	 * @param {import('./types/BuildOptions').UserscriptNameFormatter} args.userscriptNameFormatter
+	 * @param {import('./types/BuildOptions').GitRepoFromPackageOptions} options
 	 */
-	static fromPackageMetadata({ packageJsonPath = 'package.json', userscriptNameFormatter }) {
+	static fromPackageMetadata({
+		packageJsonPath = 'package.json',
+		...repoOptions
+	}) {
 		/** @type {typeof import('../package.json')} */
 		const metadata = JSON.parse(readFileSync(packageJsonPath));
 		const repoUrl = new URL(metadata.repository.url);
-		return new GitRepo(repoUrl, userscriptNameFormatter);
+		return new GitRepo(repoUrl, repoOptions);
 	}
 
 	/**
 	 * Generates a link to the section in the README for the given script.
-	 * @param {Object} args
-	 * @param {string} args.baseName Basename of the script to be linked.
-	 * @param {import('./types/UserscriptMetadata').UserscriptMetadata} args.metadata Metadata of the script to be linked.
+	 * @param {import('./types/BuildOptions').UserscriptNameFormatterData} options
 	 */
 	readmeSectionUrl({ baseName, metadata }) {
 		return `${this.repoUrl}#${slugify(this.userscriptNameFormatter({ baseName, metadata }))}`;

--- a/src/types/BuildOptions.d.ts
+++ b/src/types/BuildOptions.d.ts
@@ -1,3 +1,33 @@
 import type { UserscriptMetadata } from './UserscriptMetadata';
+import type { GitRepo } from '../github';
 
-export type UserscriptNameFormatter = ({ baseName, metadata }: { baseName: string, metadata: UserscriptMetadata }) => string;
+export type UserscriptNameFormatterData = {
+	/** Name of the userscript file (without extension). */
+	baseName: string;
+	/** Metadata of the userscript. */
+	metadata: UserscriptMetadata;
+};
+
+export type UserscriptNameFormatter = (data: UserscriptNameFormatterData) => string;
+
+export type GitRepoOptions = {
+	userscriptNameFormatter: UserscriptNameFormatter;
+};
+
+export type GitRepoFromPackageOptions = GitRepoOptions & {
+	/** Path to the `package.json` file of the repository. */
+	packageJsonPath?: string;
+};
+
+export type UserscriptBuildOptions = {
+	gitRepo: GitRepo;
+	debug?: boolean;
+};
+
+export type UserscriptMetadataOptions = {
+	gitRepo: GitRepo;
+};
+
+export type BookmarkletBuildOptions = {
+	debug?: boolean;
+};

--- a/src/types/BuildOptions.d.ts
+++ b/src/types/BuildOptions.d.ts
@@ -1,0 +1,3 @@
+import type { UserscriptMetadata } from './UserscriptMetadata';
+
+export type UserscriptNameFormatter = ({ baseName, metadata }: { baseName: string, metadata: UserscriptMetadata }) => string;

--- a/src/types/UserscriptMetadata.d.ts
+++ b/src/types/UserscriptMetadata.d.ts
@@ -12,7 +12,7 @@ export type UserscriptSpecificMetadata = {
 	'exclude-match'?: MaybeArray<string>;
 	include?: MaybeArray<string | RegExp>;
 	exclude?: MaybeArray<string | RegExp>;
-}
+};
 
 export type UserscriptDefaultMetadata = {
 	author: string;
@@ -21,7 +21,7 @@ export type UserscriptDefaultMetadata = {
 	downloadURL: string | URL;
 	updateURL: string | URL;
 	supportURL: string | URL;
-}
+};
 
 export type UserscriptMetadata = UserscriptSpecificMetadata & Partial<UserscriptDefaultMetadata>;
 

--- a/src/userscriptMetadata.js
+++ b/src/userscriptMetadata.js
@@ -2,7 +2,7 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 import { preferArray } from '@kellnerd/es-utils/array/scalar.js';
 
-import { GITHUB } from './github.js';
+import { GitRepo } from './github.js';
 
 /** @type {Array<keyof import('./types/UserscriptMetadata.js').UserscriptMetadata>} */
 const metadataOrder = [
@@ -30,20 +30,21 @@ const metadataOrder = [
 /**
  * Generates the metadata block for the given userscript from the corresponding .meta.js ES module.
  * @param {string} userscriptPath
+ * @param {GitRepo} gitRepo
  */
-export async function generateMetadataBlock(userscriptPath) {
+export async function generateMetadataBlock(userscriptPath, gitRepo) {
 	const baseName = path.basename(userscriptPath, '.user.js');
 	const date = new Date(); // current date will be used as version identifier
 	const maxKeyLength = Math.max(...metadataOrder.map((key) => key.length));
 
 	/** @type {import('./types/UserscriptMetadata.js').UserscriptDefaultMetadata} */
 	const defaultMetadata = {
-		author: GITHUB.owner,
-		namespace: GITHUB.repoUrl,
-		homepageURL: GITHUB.readmeUrl(baseName),
-		downloadURL: GITHUB.userscriptRawUrl(baseName),
-		updateURL: GITHUB.userscriptRawUrl(baseName),
-		supportURL: GITHUB.supportUrl,
+		author: gitRepo.owner,
+		namespace: gitRepo.repoUrl,
+		homepageURL: '',
+		downloadURL: gitRepo.userscriptRawUrl(baseName),
+		updateURL: gitRepo.userscriptRawUrl(baseName),
+		supportURL: gitRepo.supportUrl,
 	};
 
 	/** @type {import('./types/UserscriptMetadata.js').UserscriptMetadata} */
@@ -53,6 +54,8 @@ export async function generateMetadataBlock(userscriptPath) {
 		grant: 'none',
 		...await loadMetadata(userscriptPath),
 	};
+
+	metadata.homepageURL = gitRepo.readmeSectionUrl({ baseName, metadata });
 
 	const metadataBlock = metadataOrder.flatMap((key) => {
 		return preferArray(metadata[key])

--- a/src/userscriptMetadata.js
+++ b/src/userscriptMetadata.js
@@ -2,8 +2,6 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 import { preferArray } from '@kellnerd/es-utils/array/scalar.js';
 
-import { GitRepo } from './github.js';
-
 /** @type {Array<keyof import('./types/UserscriptMetadata.js').UserscriptMetadata>} */
 const metadataOrder = [
 	'name',
@@ -30,9 +28,9 @@ const metadataOrder = [
 /**
  * Generates the metadata block for the given userscript from the corresponding .meta.js ES module.
  * @param {string} userscriptPath
- * @param {GitRepo} gitRepo
+ * @param {import('./types/BuildOptions.js').UserscriptMetadataOptions} options
  */
-export async function generateMetadataBlock(userscriptPath, gitRepo) {
+export async function generateMetadataBlock(userscriptPath, { gitRepo }) {
 	const baseName = path.basename(userscriptPath, '.user.js');
 	const date = new Date(); // current date will be used as version identifier
 	const maxKeyLength = Math.max(...metadataOrder.map((key) => key.length));


### PR DESCRIPTION
This allows customising the name of the userscript added to each heading in `README.md`. The default value calls `camelToTitleCase(baseName)` to preserve backward compatibility.